### PR TITLE
docs(self-enterprise): sync docs with code + webhook setup

### DIFF
--- a/self-enterprise/dashboard/activity-log.md
+++ b/self-enterprise/dashboard/activity-log.md
@@ -16,9 +16,11 @@ Each row shows:
 | --- | --- |
 | Document | The credential type used (passport, Aadhaar, KYC). |
 | Security level | The assurance level the configuration required (standard or biometric). |
-| Outcome | **Verified** (passed) or **rejected** (failed). |
 | Environment | `test` or `production`. |
 | Time | When the verification finished. |
+| ID | The verification's identifier. |
+
+The pass or fail outcome isn't a column; it's the **Passed** or **Failed** section the row sits in.
 
 ## What you won't see
 

--- a/self-enterprise/dashboard/configure-a-product.md
+++ b/self-enterprise/dashboard/configure-a-product.md
@@ -6,11 +6,13 @@ A configuration always starts by choosing one of the three products. The product
 
 ## Pick a product
 
-| Product | What the user proves | Configurable rules |
+| Product | What the user proves | Rules beyond Security level + OFAC |
 | --- | --- | --- |
-| **Pre KYC** | Holds a genuine document, optionally meets an age floor, comes from an allowed country, clears OFAC | Minimum age, excluded countries, OFAC |
+| **Pre KYC** | Holds a genuine document, optionally meets an age floor, comes from an allowed country, clears OFAC | Minimum age, excluded countries, plus Additional data reveals |
 | **Age Verification** | Meets an age threshold | Minimum age |
-| **Proof of Human** | Is a unique, real human | None (uniqueness is intrinsic) |
+| **Proof of Human** | Is a unique, real human | None extra |
+
+Every product also has a **Security level** and an **OFAC** check (covered below).
 
 ## The Configure tab
 
@@ -25,14 +27,14 @@ The Configure tab has three cards on the left. On the right, a live **proof-requ
 
 The predicates the user must satisfy. The user proves each one without revealing the underlying value.
 
-* **Security level**: **Standard** verifies the document is genuine; **Biometric** also verifies the user physically scanned the document's chip.
+* **Security level** (all products): **Standard** verifies the document is genuine; **Biometric** also verifies the user physically scanned the document's chip.
+* **OFAC check** (all products, on by default): match against the US Treasury OFAC sanctions list. Self keeps the list updated daily, and only the pass or fail result is disclosed.
 * **Minimum age** (Pre KYC, Age Verification): the age threshold. Only the pass or fail result is disclosed, never the date of birth.
 * **Excluded countries** (Pre KYC): documents issued by a country on this list fail. Only the pass or fail result is disclosed, not the user's country. ISO 3166-1 alpha-3 codes.
-* **OFAC check** (Pre KYC): match against the US Treasury OFAC sanctions list. Self keeps the list updated daily, and only the pass or fail result is disclosed.
 
-### Additional data
+### Additional data (Pre KYC)
 
-Beyond the pass or fail rules, you can ask the user to disclose specific document fields. Each is an explicit reveal, **off by default**, request only what you need:
+For **Pre KYC**, beyond the pass or fail rules, you can ask the user to disclose specific document fields. Each is an explicit reveal, **off by default**, request only what you need:
 
 `Full name`, `ID number`, `Date issued`, `Date of birth`, `Gender`, `Nationality`, `Expiration date`, `Issuing state`.
 

--- a/self-enterprise/dashboard/overview.md
+++ b/self-enterprise/dashboard/overview.md
@@ -14,7 +14,7 @@ The landing surface. Shows recent activity across your products, quick links to 
 
 Each product (Pre KYC, Age Verification, Proof of Human) has its own page and holds **one active configuration at a time**. The page splits into tabs:
 
-* [Configure](configure-a-product.md): rules, documents, settings.
+* [Configure](configure-a-product.md): disclosure rules and (for Pre KYC) additional data.
 * **Deploy**: publish the configuration and generate [API keys](api-keys.md).
 * [Activity log](activity-log.md): verifications, errors over time.
 

--- a/self-enterprise/dashboard/people.md
+++ b/self-enterprise/dashboard/people.md
@@ -6,7 +6,7 @@
 
 ## Invite a teammate
 
-In the **Invite teammates** card, enter an email and click **Send invitation**. Self emails them a join link.
+In the **Invite teammates** card, enter an email, pick a **role** (`member` or `admin`; owners can also invite another `owner`), and click **Send invitation**. Self emails them a join link.
 
 * Anyone with an address on a **verified corporate domain** can accept the invitation.
 * A **consumer-domain** invite (for example a gmail.com address) is bound to the exact email you entered.
@@ -21,7 +21,7 @@ The **Team members** card lists everyone on the org and every outstanding invite
 | Status | **Active** (joined), **Invited** (pending), or **Expired**. |
 | Added | When they were invited or joined. |
 
-Pending and expired invitations have a **⋯** menu with **Resend** and **Revoke**.
+Pending and expired invitations have a **⋯** menu with **Resend** and **Revoke**. Active members can be **removed** from the org (owner/admin only). Removing a member or revoking their invite doesn't touch any API keys, those belong to the org, not the person.
 
 ## Roles
 

--- a/self-enterprise/dashboard/webhooks.md
+++ b/self-enterprise/dashboard/webhooks.md
@@ -26,13 +26,13 @@ Don't try to verify the signature yet, you don't have the signing secret until t
 
 ## Add an endpoint
 
-Click **Add endpoint** and fill in:
+Click **Add webhook** and fill in:
 
 * **Name**: a label for the endpoint.
 * **Webhook URL**: the public HTTPS URL from above.
 * **Environment**: `test` or `live` (defaults to test).
 
-When you save, Self sends the test event and waits for the result:
+When you click **Test and save**, Self sends the test event and waits for the result:
 
 * If your endpoint returns **`2xx`**, the endpoint is **saved** and the **signing secret** (`whsec_...`) is revealed **once**. This is the only time you'll see it, copy it into your secret manager as `SELF_WEBHOOK_SECRET`.
 * If it returns a non-`2xx` or doesn't respond in time, the endpoint is **not saved** ("webhook test failed"). Fix the endpoint and add it again.

--- a/self-enterprise/dashboard/webhooks.md
+++ b/self-enterprise/dashboard/webhooks.md
@@ -4,20 +4,44 @@
 
 ![Webhooks settings](../../.gitbook/assets/webhook.png)
 
+## Stand up an endpoint first
+
+When you add an endpoint, Self sends a **test event** to your URL and **only saves it if your endpoint returns `2xx`**. If the URL doesn't respond with `2xx` in time, nothing is saved and you get a "webhook test failed" error. So your endpoint has to be live and reachable **before** you add it.
+
+A handler that just returns `200` is enough to get registered:
+
+```ts
+import express from 'express';
+
+const app = express();
+
+app.post('/webhooks/self', express.raw({ type: 'application/json' }), (req, res) => {
+  res.sendStatus(200);   // accept the test event so the endpoint saves
+});
+
+app.listen(3000);
+```
+
+Don't try to verify the signature yet, you don't have the signing secret until the endpoint saves. Just return `200` for now. For local development, expose the URL publicly with a tunnel ([ngrok](https://ngrok.com), Cloudflare Tunnel, etc.).
+
 ## Add an endpoint
 
 Click **Add endpoint** and fill in:
 
 * **Name**: a label for the endpoint.
-* **Webhook URL**: the public HTTPS URL that receives the POSTs.
+* **Webhook URL**: the public HTTPS URL from above.
 * **Environment**: `test` or `live` (defaults to test).
 
-On save:
+When you save, Self sends the test event and waits for the result:
 
-* The **signing secret** (`whsec_...`) is revealed **once**. This is the only time you'll see it, copy it into your secret manager as `SELF_WEBHOOK_SECRET`.
-* Self sends a **test event** to the URL right away (shown as "Test sent") so you can confirm it's reachable.
+* If your endpoint returns **`2xx`**, the endpoint is **saved** and the **signing secret** (`whsec_...`) is revealed **once**. This is the only time you'll see it, copy it into your secret manager as `SELF_WEBHOOK_SECRET`.
+* If it returns a non-`2xx` or doesn't respond in time, the endpoint is **not saved** ("webhook test failed"). Fix the endpoint and add it again.
 
 Every endpoint receives **all** event types (`verification.completed`, `verification.storage_committed`, `verification.storage_failed`); there's no per-endpoint event picker. Branch on `event.type` in your handler. See the [event catalog](../webhooks/events.md).
+
+## Verify the signature
+
+Now that the endpoint is saved and you have the `whsec_...` secret, replace the bare `200` with real signature verification so you only act on genuine events. See [Verify webhooks](../sdk/verify-webhooks.md).
 
 ## Managing endpoints
 

--- a/self-enterprise/flows/anatomy.md
+++ b/self-enterprise/flows/anatomy.md
@@ -60,7 +60,7 @@ If you integrate against the data model directly (for example via the dashboard'
 flows
 ├─ id
 ├─ orgId
-├─ product                   ← pre_kyc | age_verification | reusable_kyc
+├─ product                   ← pre_kyc | age_verification | proof_of_human
 ├─ name
 ├─ slug
 ├─ description
@@ -69,7 +69,7 @@ flows
 ```
 
 {% hint style="info" %}
-On the wire the three products carry the internal slugs `pre_kyc`, `age_verification`, and `reusable_kyc` (the dashboard labels `reusable_kyc` as Proof of Human). When creating sessions you reference a `flowId`, never the product slug.
+On the wire the three products carry the internal slugs `pre_kyc`, `age_verification`, and `proof_of_human` (what the verifier expects). When creating sessions you reference a `flowId`, never the product slug.
 {% endhint %}
 
 ## Related

--- a/self-enterprise/flows/disclosures.md
+++ b/self-enterprise/flows/disclosures.md
@@ -30,7 +30,7 @@ Available in **Pre KYC**. Deny issuing countries with an excluded list (ISO 3166
 
 ## OFAC (predicate)
 
-Available in **Pre KYC**. The user proves they don't match the OFAC sanctions list, which Self keeps updated daily. On a match, the verification is rejected.
+Available in **all products** (a toggle, on by default). The user proves they don't match the OFAC sanctions list, which Self keeps updated daily. On a match, the verification is rejected.
 
 ```json
 { "ofac_clear": true }
@@ -42,7 +42,7 @@ The core of the **Proof of Human** product, and present implicitly in the others
 
 ## Additional data (reveals)
 
-Beyond the pass or fail predicates, you can ask the user to disclose specific document fields. Each is **off by default**, so request only what you need:
+Available in **Pre KYC**. Beyond the pass or fail predicates, you can ask the user to disclose specific document fields. Each is **off by default**, so request only what you need:
 
 `Full name`, `ID number`, `Date issued`, `Date of birth`, `Gender`, `Nationality`, `Expiration date`, `Issuing state`.
 

--- a/self-enterprise/get-started/quickstart.md
+++ b/self-enterprise/get-started/quickstart.md
@@ -34,7 +34,7 @@ Once published, your configuration has a `flowId`. Copy it.
 
 ## 3. Create an API key
 
-**Settings → API keys → Create key**. Choose `test` while you're integrating. The key (`sk_test_...`) is shown once, store it as `SELF_API_KEY` in your backend's secret manager.
+On the product's **Deploy** tab, open the **Secret API Keys (server-side)** card, keep the environment on `test`, and click **Generate test API key**. The key (`sk_test_...`) is shown once, store it as `SELF_API_KEY` in your backend's secret manager. See [API keys](../dashboard/api-keys.md).
 
 ![Test API key](../../.gitbook/assets/api-key-test.png)
 
@@ -65,7 +65,7 @@ The user opens `verificationUrl` in their Self app, produces a proof, and the ap
 
 Your endpoint has to be **running and reachable first**: when you add it, Self sends a test event and only saves it (and reveals the secret) if your endpoint returns `2xx`. Deploy the step 7 handler below (or a bare `200` stub) on a public HTTPS URL before this step. See [Webhooks: stand up an endpoint first](../dashboard/webhooks.md) for the full detail.
 
-Then in **Settings → Webhooks → Add endpoint**, paste your URL (e.g. `https://<your-tunnel>/webhooks/self`). On success the dashboard reveals a signing secret (`whsec_...`) **once**, store it as `SELF_WEBHOOK_SECRET`. Every endpoint receives all event types.
+Then in **Settings → Webhooks → Add webhook**, paste your URL (e.g. `https://<your-tunnel>/webhooks/self`). On success the dashboard reveals a signing secret (`whsec_...`) **once**, store it as `SELF_WEBHOOK_SECRET`. Every endpoint receives all event types.
 
 ## 7. Verify webhook deliveries
 

--- a/self-enterprise/get-started/quickstart.md
+++ b/self-enterprise/get-started/quickstart.md
@@ -61,11 +61,11 @@ console.log(session.verificationUrl);  // hand this to the user.
 
 The user opens `verificationUrl` in their Self app, produces a proof, and the app submits it back to us.
 
-## 6. Subscribe to webhooks
+## 6. Add a webhook endpoint
 
-**Settings → Webhooks → Add endpoint**. Paste your public URL (e.g. `https://<your-tunnel>/webhooks/self`) and subscribe to `verification.completed`.
+Your endpoint has to be **running and reachable first**: when you add it, Self sends a test event and only saves it (and reveals the secret) if your endpoint returns `2xx`. Deploy the step 7 handler below (or a bare `200` stub) on a public HTTPS URL before this step. See [Webhooks: stand up an endpoint first](../dashboard/webhooks.md) for the full detail.
 
-The dashboard returns a signing secret (`whsec_...`). Store it as `SELF_WEBHOOK_SECRET`.
+Then in **Settings → Webhooks → Add endpoint**, paste your URL (e.g. `https://<your-tunnel>/webhooks/self`). On success the dashboard reveals a signing secret (`whsec_...`) **once**, store it as `SELF_WEBHOOK_SECRET`. Every endpoint receives all event types.
 
 ## 7. Verify webhook deliveries
 

--- a/self-enterprise/get-started/quickstart.md
+++ b/self-enterprise/get-started/quickstart.md
@@ -5,7 +5,7 @@ End-to-end: from sign-up to a verified user, in about ten minutes.
 ## Prerequisites
 
 * A Self.xyz dashboard account ([sign up](https://dashboard.self.xyz)).
-* Node 18+ (for the SDK).
+* Node 20+ (for the SDK).
 * A way to receive a webhook locally, [ngrok](https://ngrok.com), Cloudflare Tunnel, or any public HTTPS endpoint.
 
 ## 1. Create your organization
@@ -53,7 +53,7 @@ const self = new SelfClient({ apiKey: process.env.SELF_API_KEY! });
 
 const session = await self.sessions.create({
   flowId: '<paste flowId from step 2>',
-  externalUuid: 'user_42',           // your stable identifier for the user.
+  externalUuid: user.id,               // your stable UUID for this user.
 });
 
 console.log(session.verificationUrl);  // hand this to the user.

--- a/self-enterprise/reference/troubleshooting.md
+++ b/self-enterprise/reference/troubleshooting.md
@@ -104,7 +104,7 @@ Expected. We deliver at-least-once. See [Best practices](../webhooks/best-practi
 
 ### `Cannot find module '@selfxyz/enterprise-sdk'`
 
-The package is ESM-only and requires Node 18+.
+The package is ESM-only and requires Node 20+.
 
 * Confirm Node version (`node -v`).
 * Confirm your `package.json` has `"type": "module"`, or you're using `.mjs` files, or your build system supports ESM.

--- a/self-enterprise/sdk/api-reference.md
+++ b/self-enterprise/sdk/api-reference.md
@@ -13,6 +13,7 @@ import {
   SelfClient,               // the API client
   SelfWebhooks,             // webhook signature verification
   SelfApiError,             // thrown on a non-2xx API response
+  SelfValidationError,      // thrown on invalid input / unknown payload
   WebhookVerificationError, // thrown on a bad webhook signature
 } from '@selfxyz/enterprise-sdk';
 
@@ -52,7 +53,7 @@ Creates a verification session against the published flow and returns a URL to s
 | Field | Type | Required | Notes |
 | --- | --- | :---: | --- |
 | `flowId` | string (UUID) | ✅ | The flow to verify against. |
-| `externalUuid` | string | ✅ | Your stable identifier for the user. 1 to 128 chars. |
+| `externalUuid` | string (UUID) | ✅ | Your stable identifier for the user. Must be a UUID. |
 | `expiresInSeconds` | number | No | How long the session stays openable. Integer, 60 to 86400. Default 3600. |
 | `metadata` | object | No | Arbitrary JSON attached to the session. Max 4 KB serialized. |
 | `successUrl` | string (URL) | No | Where the hosted page sends the user on success. |
@@ -122,7 +123,7 @@ Verifies a webhook signature and returns the typed, parsed event.
 | `headers` | Must include `svix-id`, `svix-timestamp`, `svix-signature`. |
 | `secret` | The endpoint's signing secret (`whsec_…`). |
 
-Throws [`WebhookVerificationError`](#webhookverificationerror) if the signature is invalid or the timestamp is stale, and a Zod `ZodError` if the body doesn't match any known event shape (usually an out-of-date SDK).
+Throws [`WebhookVerificationError`](#webhookverificationerror) if the signature is invalid or the timestamp is stale, and [`SelfValidationError`](#selfvalidationerror) if the body doesn't match any known event shape (usually an out-of-date SDK).
 
 **`WebhookEvent`** is a discriminated union on `type`:
 
@@ -149,8 +150,18 @@ Thrown when the API returns a non-2xx response.
 | `code` | string | Stable machine-readable code (`validation_failed`, `not_found`, ...). |
 | `message` | string | Human-readable. |
 | `details` | `Record<string, unknown>` \| undefined | Extra context (for example validation `issues`). |
+| `requestId` | string \| undefined | The `X-Request-Id` response header, when present. Quote it to support. |
 
 See [Error handling](error-handling.md) for the code catalog.
+
+### `SelfValidationError`
+
+Thrown when arguments fail schema validation **before** a request is sent (for example a `flowId` or `externalUuid` that isn't a UUID), and by `SelfWebhooks.verify(...)` when a verified payload doesn't match any known event shape.
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `issues` | `ZodIssue[]` | Which fields failed and why. |
+| `message` | string | Human-readable summary. |
 
 ### `WebhookVerificationError`
 

--- a/self-enterprise/sdk/api-reference.md
+++ b/self-enterprise/sdk/api-reference.md
@@ -165,7 +165,7 @@ Thrown when arguments fail schema validation **before** a request is sent (for e
 
 ### `WebhookVerificationError`
 
-Re-exported from `svix`. Thrown by `SelfWebhooks.verify(...)` on a bad signature, stale timestamp, or missing headers. Respond `400`, a bad signature won't pass on retry.
+Thrown by `SelfWebhooks.verify(...)` on a bad signature, stale timestamp, or missing headers. Respond `400`, a bad signature won't pass on retry.
 
 ## Related
 

--- a/self-enterprise/sdk/error-handling.md
+++ b/self-enterprise/sdk/error-handling.md
@@ -1,6 +1,6 @@
 # SDK error handling
 
-The SDK throws two error classes. Catch them by type.
+The SDK throws three error classes. Catch them by type.
 
 ## `SelfApiError`
 
@@ -17,6 +17,7 @@ try {
     err.code;        // string ('validation_failed', 'not_found', 'unauthenticated', ...)
     err.message;     // string (human-readable)
     err.details;     // Record<string, unknown> | undefined
+    err.requestId;   // string | undefined (X-Request-Id; quote it to support)
   } else {
     throw err;       // network error, or something unexpected
   }
@@ -64,6 +65,25 @@ try {
 | `vendor_unavailable` | 503 | A dependency is temporarily unavailable. | Retry with backoff. |
 | `internal_error` | 500 | Server-side error. | Retry with backoff; if it persists, contact support. |
 
+## `SelfValidationError`
+
+Thrown when the arguments you pass fail schema validation, **before** any request goes out. The most common cause is a `flowId` or `externalUuid` that isn't a UUID. It also comes from `SelfWebhooks.verify(...)` when a verified payload doesn't match any known event shape.
+
+```ts
+import { SelfValidationError } from '@selfxyz/enterprise-sdk';
+
+try {
+  await self.sessions.create({ flowId, externalUuid });
+} catch (err) {
+  if (err instanceof SelfValidationError) {
+    err.issues;   // ZodIssue[], which fields are wrong
+    err.message;  // e.g. "Invalid sessions.create input: flowId (invalid uuid)"
+  }
+}
+```
+
+Fix the input; it's a programming error, not a transient one.
+
 ## `WebhookVerificationError`
 
 Thrown by `SelfWebhooks.verify(...)` when the signature doesn't match the body, the timestamp is too old, or required headers are missing.
@@ -80,7 +100,7 @@ try {
 }
 ```
 
-A separate failure mode: if the signature checks out but the body doesn't match any known event schema, `verify(...)` throws a Zod `ZodError`. That usually means the server is sending a newer event type than your SDK version knows, upgrade the SDK.
+A separate failure mode: if the signature checks out but the body doesn't match any known event schema, `verify(...)` throws `SelfValidationError`. That usually means the server is sending a newer event type than your SDK version knows, upgrade the SDK.
 
 ## Retries
 
@@ -95,6 +115,7 @@ log.error({
   msg: 'self_api_error',
   statusCode: err.statusCode,
   code: err.code,
+  requestId: err.requestId,
   details: err.details,
 });
 ```

--- a/self-enterprise/sdk/nodejs.md
+++ b/self-enterprise/sdk/nodejs.md
@@ -36,7 +36,7 @@ const self = new SelfClient({
 });
 ```
 
-The API key is the only thing you pass. Whether the client talks to test or live is determined by the key prefix (`sk_test_` or `sk_live_`).
+The API key is the only option you need to pass. Whether the client talks to test or live is determined by the key prefix (`sk_test_` or `sk_live_`).
 
 ## Sessions
 

--- a/self-enterprise/sdk/nodejs.md
+++ b/self-enterprise/sdk/nodejs.md
@@ -24,7 +24,7 @@ yarn add @selfxyz/enterprise-sdk
 {% endtab %}
 {% endtabs %}
 
-Node 18+. ESM-only.
+Node 20+. ESM-only.
 
 ## Initialize
 
@@ -47,12 +47,12 @@ Get the `flowId` by publishing a configuration in the dashboard, it's shown on t
 ```ts
 const session = await self.sessions.create({
   flowId: '9c0b4f1c-1d6c-4f1b-a8c4-9f0fa0a8d9e2',
-  externalUuid: 'user_42',
+  externalUuid: 'a1b2c3d4-5678-4e9a-b012-3456789abcde',  // a UUID, your stable id for the user
   // optional:
   expiresInSeconds: 3600,
   metadata: { campaign: 'winter-2026' },
-  successUrl: 'https://app.example.com/verified?u=42',
-  failureUrl: 'https://app.example.com/failed?u=42',
+  successUrl: 'https://app.example.com/verified',
+  failureUrl: 'https://app.example.com/failed',
 });
 
 session.verificationUrl;  // give to the user
@@ -144,11 +144,12 @@ try {
     err.code;          // 'validation_failed' | 'unauthenticated' | 'not_found' | ...
     err.message;       // human-readable
     err.details;       // optional extra context (Record<string, unknown>)
+    err.requestId;     // X-Request-Id, quote it to support
   }
 }
 ```
 
-The SDK doesn't retry, handle transient `429` and `5xx` responses yourself (back off and retry). See [Error handling](error-handling.md) for the full code catalog.
+Bad arguments (for example a `flowId` or `externalUuid` that isn't a UUID) throw `SelfValidationError` before any request is sent. The SDK doesn't retry, handle transient `429` and `5xx` responses yourself (back off and retry). See [Error handling](error-handling.md) for the full code catalog.
 
 ## Compatibility
 

--- a/self-enterprise/sdk/verify-webhooks.md
+++ b/self-enterprise/sdk/verify-webhooks.md
@@ -8,7 +8,7 @@ You need:
 
 * The **raw** request body (string or Buffer). Not the JSON-parsed object, signature verification operates on the byte string.
 * The request headers, at minimum `svix-id`, `svix-timestamp`, `svix-signature`.
-* The signing secret (`whsec_...`) for the webhook endpoint, from the dashboard.
+* The signing secret (`whsec_...`) for the webhook endpoint. You get it when you [add the endpoint](../dashboard/webhooks.md) (revealed once); note the endpoint must return `2xx` to be saved.
 
 ## Express
 

--- a/self-enterprise/sdk/verify-webhooks.md
+++ b/self-enterprise/sdk/verify-webhooks.md
@@ -46,7 +46,7 @@ app.post(
       if (err instanceof WebhookVerificationError) {
         res.status(400).end();
       } else {
-        // Schema mismatch (ZodError) or server bug, log and 5xx so we retry.
+        // Unknown payload shape (SelfValidationError) or server bug, log and 5xx so we retry.
         res.status(500).end();
       }
     }

--- a/self-enterprise/webhooks/events.md
+++ b/self-enterprise/webhooks/events.md
@@ -12,7 +12,7 @@ Fires when off-chain verification finishes, either successfully or with a defini
 {
   "type": "verification.completed",
   "verification_id": "7f3b2a1e-9c4d-4b2a-8e1f-2c6d5a4b3c2d",
-  "external_uuid": "user_42",
+  "external_uuid": "a1b2c3d4-5678-4e9a-b012-3456789abcde",
   "flow_id": "9c0b4f1c-1d6c-4f1b-a8c4-9f0fa0a8d9e2",
   "flow_version_id": "b1e2c3d4-5678-4abc-9def-0123456789ab",
   "environment": "live",
@@ -67,12 +67,14 @@ Fires when the async decentralized-storage write for a verification succeeds.
 {
   "type": "verification.storage_committed",
   "verification_id": "7f3b2a1e-9c4d-4b2a-8e1f-2c6d5a4b3c2d",
-  "external_uuid": "user_42",
+  "external_uuid": "a1b2c3d4-5678-4e9a-b012-3456789abcde",
   "storage_uri": "ipfs://bafy...",
   "credential_id": "cred_01H...",
   "committed_at": "2026-05-29T17:33:25.110Z"
 }
 ```
+
+`storage_uri` may be `null`; the `credential_id` is always present on this event.
 
 ### When you'd care
 
@@ -97,7 +99,7 @@ Fires when the storage write permanently fails (after retries exhausted).
 {
   "type": "verification.storage_failed",
   "verification_id": "7f3b2a1e-9c4d-4b2a-8e1f-2c6d5a4b3c2d",
-  "external_uuid": "user_42",
+  "external_uuid": "a1b2c3d4-5678-4e9a-b012-3456789abcde",
   "error": "ipfs_pin_timeout",
   "failed_at": "2026-05-29T17:34:00.000Z"
 }

--- a/self-enterprise/webhooks/overview.md
+++ b/self-enterprise/webhooks/overview.md
@@ -12,7 +12,7 @@ Webhooks are the canonical way to learn that a verification finished. Polling wo
 ```
 ┌──────────────┐   1. signed POST (event)     ┌──────────────────┐
 │     Self     │ ───────────────────────────▶ │  Your endpoint   │
-│ (dispatcher) │                              │  verify the sig, │
+│              │                              │  verify the sig, │
 │              │ ◀─────────────────────────── │  then return 2xx │
 └──────────────┘   2. ack (2xx)               └──────────────────┘
 

--- a/self-enterprise/webhooks/overview.md
+++ b/self-enterprise/webhooks/overview.md
@@ -4,7 +4,7 @@ Webhooks are the canonical way to learn that a verification finished. Polling wo
 
 ## How they work
 
-1. You register an HTTPS endpoint in the dashboard ([Settings → Webhooks](../dashboard/webhooks.md)). Every endpoint receives **all** event types.
+1. You register an HTTPS endpoint in the dashboard ([Settings → Webhooks](../dashboard/webhooks.md)). It must be live and return `2xx` to the test event to be saved, then you get the signing secret. Every endpoint receives **all** event types.
 2. When an event fires, we POST a JSON payload to your endpoint, signed so you can verify it came from us.
 3. Your handler verifies the signature (via the SDK) and processes the event.
 4. You return `2xx` to acknowledge. A non-2xx (or timeout) triggers a retry.

--- a/self-enterprise/webhooks/signature-verification.md
+++ b/self-enterprise/webhooks/signature-verification.md
@@ -23,7 +23,7 @@ See [SDK: Verify webhooks](../sdk/verify-webhooks.md) for the full setup includi
 
 ## Other languages
 
-The Node SDK is the official client today. From any other language, verify manually with HMAC-SHA256 (see below). The headers and scheme are standard, so a Svix-compatible verification library works too.
+The Node SDK is the official client today. From any other language, verify manually with HMAC-SHA256 (see below). The scheme is standard, so an off-the-shelf webhook-signature library that follows it works too.
 
 ## Manual verification
 


### PR DESCRIPTION
## Revamp Self Enterprise docs + sync with code

Enterprise-first rewrite of the Self Enterprise docs, audited end-to-end against the actual code (control-plane-api, edge-api, the Enterprise SDK, schemas, and the dashboard frontend) so every claim matches what ships.

### Structure
- Reorganized the docs enterprise-first: Get started → Dashboard → SDK → Webhooks → Flows → Billing → Migration → Reference.
- Documented the three products: **Pre KYC**, **Age Verification**, **Proof of Human**.
- Removed dead/legacy pages (publish-a-flow-version, invoices, the REST API reference, the open-source overview).

### Synced with code
- `externalUuid` is a **UUID** (updated every example + field note).
- SDK requires **Node 20+**; `@selfxyz/enterprise-sdk` v0.2.0.
- Documented **`SelfValidationError`** and **`SelfApiError.requestId`**; `SelfWebhooks.verify` throws `SelfValidationError` (not `ZodError`).
- **OFAC and Security level apply to all three products**; **Additional data reveals are Pre KYC only**.
- Flows are immutable once published (archive + create a new one to change).
- `verification.storage_committed.storage_uri` is nullable.
- Session statuses: `pending | valid | invalid | error | expired`.

### Dashboard accuracy (vs `apps/dashboard-web`)
- API keys are generated on a product's **Deploy** tab (Secret API Keys card), not in Settings.
- Real UI labels: **Add webhook**, **Test and save**, **Generate {env} API key**.
- Settings tabs: General, Usage & Billing, Webhooks, Audit, People, System Status.
- Activity log columns corrected (Document, Security level, Environment, Time, ID); outcome is the Passed/Failed grouping, not a column.
- People (invite roles, resend/revoke/remove) and Billing (usage meter, plan, Stripe portal) match the UI; removed a non-existent low-balance/overage control.

### Webhook setup
- New guidance: an endpoint must be live and return **`2xx`** to the test event before it's saved and the signing secret (`whsec_…`) is revealed once. Includes a minimal `200` stub and "verify the signature only after you have the secret."
- Linked that prerequisite from the **Quickstart**, **SDK verify-webhooks**, and **Webhooks overview**.