### PR TITLE
docs(agent-id): migrate API references to agent-api.self.xyz; retire consumer UI

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -72,6 +72,8 @@
 * [SDK Integration](agent-id/sdk-integration.md)
 * [Verification Patterns](agent-id/verification-patterns.md)
 * [Smart Contracts](agent-id/smart-contracts.md)
+* [ERC-8004 & Proof-of-Human](agent-id/erc-8004.md)
+* [Agent Registration JSON & Agent Cards](agent-id/agent-registration-json.md)
 * [REST API](agent-id/rest-api.md)
 * [CLI](agent-id/cli.md)
 * [Celo Agent Visa](agent-id/celo-agent-visa.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -67,6 +67,7 @@
 ## Self Agent ID
 
 * [Overview](agent-id/overview.md)
+* [Register Without the Web App](agent-id/register-without-the-app.md)
 * [Registration Modes](agent-id/registration-modes.md)
 * [SDK Integration](agent-id/sdk-integration.md)
 * [Verification Patterns](agent-id/verification-patterns.md)

--- a/agent-id/agent-registration-json.md
+++ b/agent-id/agent-registration-json.md
@@ -107,7 +107,7 @@ Agents registered through the **Hub V2 Self Protocol flow** (the `verifySelfProo
 You **must** call `setAgentURI()` after registration:
 
 ```solidity
-registry.setAgentURI(agentId, "https://my-agent.example.com/.well-known/agent.json");
+registry.setAgentURI(agentId, "https://my-agent.example.com/.well-known/agent-card.json");
 ```
 
 Until `setAgentURI()` is called:

--- a/agent-id/agent-registration-json.md
+++ b/agent-id/agent-registration-json.md
@@ -1,0 +1,183 @@
+---
+description: The ERC-8004 registration document and A2A Agent Card served at an agent's agentURI
+---
+
+# Agent Registration JSON & Agent Cards
+
+Every agent registered with `SelfAgentRegistry` can publish a JSON document at its `agentURI`. This file is the agent's identity document: it is how services, indexers, and [8004scan](https://8004scan.xyz) discover and verify the agent's capabilities.
+
+## How it relates to A2A
+
+The document at `agentURI` is an ERC-8004 registration file. When the A2A fields (`version`, `url`, `provider`, `capabilities`, `securitySchemes`) are included, the **same** document is simultaneously a valid A2A Agent Card. There is no second document and no separate A2A registration step. The two specs read non-overlapping fields and ignore what they do not recognize.
+
+```
+ERC-8004 reads: type, name, description, image, services[], active, registrations[], supportedTrust[]
+A2A reads:      name, description, url, version, provider, capabilities, securitySchemes,
+                skills[], defaultInputModes, defaultOutputModes
+```
+
+## Minimal ERC-8004 format
+
+Enough for the on-chain registry and 8004scan:
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "My Agent",
+  "description": "What this agent does",
+  "image": "https://example.com/avatar.png",
+  "services": [
+    {
+      "name": "A2A",
+      "endpoint": "https://my-agent.example.com/a2a",
+      "version": "1.0"
+    }
+  ]
+}
+```
+
+## Combined ERC-8004 + A2A format
+
+Adding the A2A fields makes this single document a valid A2A Agent Card too:
+
+```json
+{
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
+  "name": "My Agent",
+  "description": "A human-backed AI agent verified via Self Protocol",
+  "image": "https://my-agent.example.com/avatar.png",
+  "version": "0.1.0",
+  "url": "https://my-agent.example.com/a2a",
+  "provider": { "name": "Acme Corp", "url": "https://acme.example.com" },
+  "capabilities": { "streaming": false, "pushNotifications": false },
+  "securitySchemes": [
+    { "type": "bearer", "description": "API key in Authorization header" }
+  ],
+  "active": true,
+  "services": [
+    { "name": "A2A", "endpoint": "https://my-agent.example.com/a2a", "version": "1.0" },
+    { "name": "MCP", "endpoint": "https://my-agent.example.com/mcp", "version": "1.0" }
+  ],
+  "registrations": [
+    {
+      "agentId": 42,
+      "agentRegistry": "eip155:42220:0xaC3DF9ABf80d0F5c020C06B04Cced27763355944"
+    }
+  ],
+  "supportedTrust": ["reputation"]
+}
+```
+
+## Field reference
+
+| Field | Required | Protocol | Notes |
+|-------|----------|----------|-------|
+| `type` | YES | ERC-8004 | Must be `"https://eips.ethereum.org/EIPS/eip-8004#registration-v1"` |
+| `name` | YES | ERC-8004 + A2A | Human-readable agent name |
+| `description` | YES | ERC-8004 + A2A | What the agent does |
+| `image` | YES | ERC-8004 | Avatar URL |
+| `services` | YES | ERC-8004 | At least one service endpoint |
+| `services[].name` | YES | ERC-8004 | One of: `web`, `A2A`, `MCP`, `OASF`, `ENS`, `DID`, `email` |
+| `services[].endpoint` | YES | ERC-8004 | Service URI |
+| `services[].version` | YES (for A2A/MCP) | ERC-8004 | Required by A2A protocol, e.g. `"1.0"` |
+| `active` | NO | ERC-8004 | Set `false` when the agent is inactive (e.g. proof expired) |
+| `registrations` | NO | ERC-8004 | Cross-chain registry refs using CAIP-10: `eip155:<chainId>:<address>` |
+| `supportedTrust` | NO | ERC-8004 | `reputation`, `crypto-economic`, `tee-attestation` |
+| `version` | NO\* | A2A | Agent **software** version (e.g. `"0.1.0"`). \*Required for an A2A Agent Card |
+| `url` | NO\* | A2A | A2A primary endpoint. MUST equal `services[name="A2A"].endpoint`. \*Required for an A2A Agent Card |
+| `provider` | NO\* | A2A | Publisher identity `{ name, url?, email? }`. \*Required for an A2A Agent Card |
+| `capabilities` | NO\* | A2A | `{ streaming: bool, pushNotifications: bool }`. \*Required for an A2A Agent Card |
+| `securitySchemes` | NO\* | A2A | Auth methods. `{ type: "bearer" \| "apiKey" \| "oauth2" \| "none" }[]`. \*Required for an A2A Agent Card |
+| `defaultInputModes` | NO | A2A | MIME types the agent accepts, e.g. `["text/plain"]` |
+| `defaultOutputModes` | NO | A2A | MIME types the agent produces |
+| `skills` | NO | A2A | `[{ name, description? }]` — specific tasks the agent offers |
+
+## Constraints when combining the two
+
+- `url` (the A2A primary endpoint) and `services[name="A2A"].endpoint` **MUST** point to the same address. A2A clients read `url`; ERC-8004 indexers read `services`.
+- `version` = agent **software** version (e.g. `"0.1.0"`); `services[].version` = **protocol** version (e.g. `"1.0"`). These are distinct fields.
+- The path `/.well-known/agent-card.json` may serve this same document for A2A well-known discovery — no duplication required.
+
+## Agents minted via Self Protocol start with a blank agentURI
+
+{% hint style="warning" %}
+Agents registered through the **Hub V2 Self Protocol flow** (the `verifySelfProof` callback that mints the NFT) are created with a **blank `agentURI`**. The on-chain `Registered` event carries an empty string for the URI.
+{% endhint %}
+
+You **must** call `setAgentURI()` after registration:
+
+```solidity
+registry.setAgentURI(agentId, "https://my-agent.example.com/.well-known/agent.json");
+```
+
+Until `setAgentURI()` is called:
+
+- 8004scan indexes the agent with no identity document
+- A2A clients cannot discover your service endpoints
+- The `active` and `services` fields are invisible to the ecosystem
+
+This does not apply to agents registered via the `register(agentURI)` or `registerWithHumanProof(agentURI, ...)` overloads, which accept a URI directly.
+
+## On-chain metadata
+
+When registered via `SelfAgentRegistry`, agents can carry key-value metadata set with `setMetadata(agentId, key, value)`:
+
+| Key | Description |
+|-----|-------------|
+| `agentWallet` | Reserved. Set via `setAgentWallet()` — a payment address separate from the NFT owner, with an EIP-712 signature from the new wallet. |
+
+Any custom key is allowed except the reserved `agentWallet`.
+
+## SDK helper
+
+The TypeScript SDK builds valid documents with `generateRegistrationJSON`:
+
+```typescript
+import { generateRegistrationJSON } from "@selfxyz/agent-sdk";
+
+// Minimal ERC-8004 only
+const minimalDoc = generateRegistrationJSON({
+  name: "My Agent",
+  description: "What it does",
+  image: "https://...",
+  services: [{ name: "A2A", endpoint: "https://...", version: "1.0" }],
+});
+
+// Combined ERC-8004 + A2A (single document, both protocols)
+const fullDoc = generateRegistrationJSON({
+  name: "My Agent",
+  description: "What it does",
+  image: "https://...",
+  services: [
+    { name: "A2A", endpoint: "https://my-agent.example.com/a2a", version: "1.0" },
+  ],
+  a2a: {
+    version: "0.1.0",
+    url: "https://my-agent.example.com/a2a",
+    provider: { name: "Acme Corp" },
+    capabilities: { streaming: false, pushNotifications: false },
+    securitySchemes: [{ type: "bearer" }],
+  },
+});
+```
+
+## Hosting requirements
+
+The JSON file must be:
+
+1. Accessible over HTTPS at the `agentURI` provided during registration
+2. Served with `Content-Type: application/json`
+3. Updated whenever the agent's services or status change (update the document, then call `setAgentURI()` if the URL itself moved)
+
+## Validation
+
+Use the 8004scan validator at [8004scan.xyz](https://8004scan.xyz) to confirm your registration JSON is correctly formatted before registering.
+
+## Where the API serves cards from
+
+The API reads the on-chain `agentMetadata` and serves the stored card as HTTP JSON, so you do not have to host anything yourself if you set the card on-chain:
+
+- `GET /api/cards/{chainId}/{agentId}` — the Agent Card JSON
+- `GET /.well-known/a2a/{agentId}?chain={chainId}` — redirects to the card resolver
+
+See [REST API](rest-api.md) and [SDK Integration](sdk-integration.md#a2a-agent-cards).

--- a/agent-id/celo-agent-visa.md
+++ b/agent-id/celo-agent-visa.md
@@ -37,7 +37,7 @@ The contract is a soulbound ERC-721 (non-transferable) using UUPS upgradeable pa
 
 ## API Endpoints
 
-All visa endpoints are served from the Self Agent ID web app.
+All visa endpoints are served at `https://agent-api.self.xyz`. The read endpoints are wrappers over `CeloAgentVisa` contract reads, so you can also call the contract directly; the claim and review endpoints use a relayer.
 
 ### Get Visa Status
 

--- a/agent-id/cli.md
+++ b/agent-id/cli.md
@@ -157,24 +157,79 @@ For automated onboarding, your backend or agent runtime orchestrates the CLI com
 The agent-guided flow is the recommended integration pattern for services that onboard users programmatically. The CLI handles all the complexity of session management and proof verification.
 {% endhint %}
 
-## Session Schema (v1)
+## Canonical challenge domain
 
-The session file (`.self/session.json`) contains:
+For every mode except `self-custody`, the agent key signs a challenge proving it controls the key. All SDKs hash the same domain so a session created by one CLI is verifiable by any other:
 
-```json
-{
-  "version": 1,
-  "mode": "linked",
-  "network": "mainnet",
-  "humanAddress": "0x...",
-  "agentAddress": "0x...",
-  "agentPrivateKey": "0x...",
-  "sessionId": "uuid",
-  "handoffUrl": "https://agent-api.self.xyz/qr/...",
-  "status": "pending",
-  "createdAt": "2026-02-22T..."
-}
 ```
+keccak256(abi.encodePacked("self-agent-id:register:", humanIdentifier, chainId, registryAddress, nonce))
+```
+
+The hashing and the `(r, s, v)` signature split must match across TypeScript, Python, and Rust. The same value is reproduced on-chain when the registry verifies the agent signature alongside the Self ZK proof.
+
+## Session schema (v1)
+
+The session file (`.self/session.json`) is a structured record, not a flat blob. Top-level keys:
+
+| Key | Notes |
+|-----|-------|
+| `version` | Schema version (`1`) |
+| `operation` | `register` or `deregister` |
+| `sessionId`, `createdAt`, `expiresAt` | Session identity and TTL |
+| `mode`, `disclosures` | Registration mode and selected disclosures |
+| `network` | `{ chainId, rpcUrl, registryAddress, endpointType, appUrl, appName, scope }` |
+| `registration` | `{ humanIdentifier, agentAddress, userDefinedData, challengeHash, signature, smartWalletTemplate? }` (`challengeHash`/`signature` for non-`self-custody` modes) |
+| `callback` | `{ listenHost: "127.0.0.1", listenPort, path: "/callback", stateToken, used, lastStatus?, lastError? }` |
+| `state` | `{ stage, updatedAt, lastError?, agentId?, guardianAddress? }` |
+| `secrets` | `{ agentPrivateKey }` — generated-key modes only (`linked`, `wallet-free`, `smartwallet`) |
+
+### Local session stages
+
+The local session file moves through these `state.stage` values:
+
+```
+initialized → handoff_opened → callback_received → onchain_verified
+                                                  → onchain_deregistered   (deregister flow)
+                                                  → failed | expired
+```
+
+{% hint style="info" %}
+These are the **local CLI** stages. They are distinct from the **API** registration stages (`qr-ready`, `proof-received`, `completed`, `failed`) returned by `GET /api/agent/register/status`. The CLI reconciles the API/on-chain state into its own session file.
+{% endhint %}
+
+## Browser handoff & callback contract
+
+`register open` encodes the session into a `payload=<base64url(json)>` parameter for the API's `/cli/register` handoff page. The payload carries: `version`, `operation`, `sessionId`, `stateToken`, `callbackUrl`, `mode`, `chainId`, `registryAddress`, `endpointType`, `appName`, `scope`, `humanIdentifier`, `expectedAgentAddress`, `expiresAt`, and optionally `disclosures`, `userDefinedData`, `smartWalletTemplate`.
+
+When the browser flow completes, it POSTs JSON back to the CLI's loopback callback (`http://127.0.0.1:<port>/callback`): `{ sessionId, stateToken, status: "success" | "error", timestamp, operation?, error?, guardianAddress? }`. The CLI rejects callbacks whose `sessionId` / `stateToken` do not match, and rejects replays.
+
+## Security
+
+1. Exporting the agent private key is blocked unless `--unsafe` is passed explicitly.
+2. Session and key files use restricted file permissions. Treat them as sensitive local state.
+3. The callback listener binds to the loopback host only.
+4. Session expiry is enforced before handoff and wait operations.
+5. Rotate or delete old session files after a successful registration.
+
+## Refreshing an expired proof
+
+Human proofs expire at `min(document expiry, registration time + maxProofAge)` (default `maxProofAge` ≈ 365 days). After expiry, `isProofFresh(agentId)` returns `false`. The CLI surfaces `proofExpiresAt` in `register status` and warns when expiry is within 30 days.
+
+There is no in-place CLI refresh command. To refresh, run the full deregister flow then a new register flow, which mints a **new** `agentId` (update any stored references):
+
+```bash
+self-agent deregister init --mode linked --human-address 0x... --agent-address 0x... --network mainnet --out .self/dereg.json
+self-agent deregister open --session .self/dereg.json    # complete Self proof
+self-agent deregister wait --session .self/dereg.json
+
+self-agent register init --mode linked --human-address 0x... --network mainnet --out .self/refresh.json
+self-agent register open --session .self/refresh.json     # complete Self proof
+self-agent register wait --session .self/refresh.json
+```
+
+{% hint style="info" %}
+The REST API also exposes an in-place [refresh endpoint](rest-api.md#proof-refresh-endpoints) (`POST /api/agent/refresh`) that re-proves an existing agent without minting a new ID. The CLI does not wrap it yet.
+{% endhint %}
 
 ## Network Flag
 

--- a/agent-id/cli.md
+++ b/agent-id/cli.md
@@ -6,6 +6,10 @@ description: Terminal-based agent registration and deregistration workflows
 
 Self Agent ID includes a cross-language CLI for registering and deregistering agents from the terminal. Available in TypeScript, Python, and Rust with identical command surfaces.
 
+{% hint style="info" %}
+The CLI talks to the API at `https://agent-api.self.xyz`. Override it with the `SELF_AGENT_API_BASE` environment variable if you run your own deployment. The CLI fetches the scannable QR from the API (`GET /api/qr/{sessionToken}`), so no consumer web app is needed.
+{% endhint %}
+
 ## Install
 
 {% tabs %}
@@ -166,7 +170,7 @@ The session file (`.self/session.json`) contains:
   "agentAddress": "0x...",
   "agentPrivateKey": "0x...",
   "sessionId": "uuid",
-  "handoffUrl": "https://selfagentid.xyz/cli/register?session=...",
+  "handoffUrl": "https://agent-api.self.xyz/qr/...",
   "status": "pending",
   "createdAt": "2026-02-22T..."
 }

--- a/agent-id/erc-8004.md
+++ b/agent-id/erc-8004.md
@@ -1,0 +1,166 @@
+---
+description: How Self Agent ID implements ERC-8004 and the proposed Proof-of-Human extension
+---
+
+# ERC-8004 & Proof-of-Human
+
+Self Agent ID is a reference implementation of [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) plus a proposed optional **Proof-of-Human** extension. This page explains the standard, the extension interfaces, and how Self maps onto all three ERC-8004 registry types.
+
+## What is ERC-8004?
+
+ERC-8004 is a proposed standard for on-chain AI agent registries. It defines a minimal interface for registering agents, assigning them unique IDs (as NFTs), and looking up agent ownership. Think of it as a universal, composable identity layer for agents.
+
+The base standard is intentionally minimal. It does not specify how agents are verified or who operates them. That is where optional extensions come in, similar to how ERC-721 defines optional Metadata and Enumerable extensions within the same EIP.
+
+```solidity
+/// @title IERC8004 - Agent Registry (Base Standard)
+interface IERC8004 {
+    function registerAgent(bytes32 agentPubKey) external returns (uint256);
+    function getAgentId(bytes32 agentPubKey) external view returns (uint256);
+    function ownerOf(uint256 agentId) external view returns (address);
+}
+```
+
+Self's `SelfAgentRegistry` implements the fuller base surface that the EIP draft describes: `register()` overloads, `setAgentURI`, key-value metadata, and agent-wallet binding. See [Smart Contracts](smart-contracts.md) for the deployed interface.
+
+## The problem the extension solves
+
+ERC-8004 registers agents, but it does not answer the critical question: **is this agent operated by a real, unique human?**
+
+Without proof-of-human, anyone can register unlimited agents, enabling sybil attacks, bot farms, and impersonation. Protocols that gate access to "verified agents" have no standard way to check humanity, so every project builds its own solution and the ecosystem fragments.
+
+## Design principles
+
+The proposed `IERC8004ProofOfHuman` extension is additive: it inherits from `IERC8004` and adds only proof-of-human registration, revocation, and query functions. Three principles guide it:
+
+- **Provider-agnostic.** Any ZK identity system (Self Protocol, World ID, Humanity Protocol) can implement `IHumanProofProvider`. The registry does not care how humanity is proven.
+- **Sybil-resistant.** Each human produces a unique, scoped nullifier. The registry tracks agent counts per nullifier, and services choose their own limits (1, N, or unlimited).
+- **Privacy-preserving.** Only a nullifier is stored on-chain. No name, no passport number, no biometrics. ZK proofs verify humanity without revealing identity.
+
+## The extension interface
+
+```solidity
+/// @title IERC8004ProofOfHuman
+/// @notice Optional extension to ERC-8004 adding proof-of-human verification
+interface IERC8004ProofOfHuman is IERC8004 {
+    // ── Registration ──────────────────────────────
+    function registerWithHumanProof(
+        string calldata agentURI,
+        address proofProvider,
+        bytes calldata proof,
+        bytes calldata providerData
+    ) external returns (uint256 agentId);
+
+    function revokeHumanProof(
+        uint256 agentId,
+        address proofProvider,
+        bytes calldata proof,
+        bytes calldata providerData
+    ) external;
+
+    // ── Verification (read by any service/contract) ─
+    function hasHumanProof(uint256 agentId) external view returns (bool);
+    function proofExpiresAt(uint256 agentId) external view returns (uint256);
+    function isProofFresh(uint256 agentId) external view returns (bool);
+    function getHumanNullifier(uint256 agentId) external view returns (uint256);
+    function getProofProvider(uint256 agentId) external view returns (address);
+    function isApprovedProvider(address provider) external view returns (bool);
+
+    // ── Sybil detection ───────────────────────────
+    function getAgentCountForHuman(uint256 nullifier) external view returns (uint256);
+    function sameHuman(uint256 a, uint256 b) external view returns (bool);
+}
+```
+
+### The pluggable provider interface
+
+```solidity
+/// @title IHumanProofProvider
+/// @notice Pluggable identity backend for proof-of-human
+interface IHumanProofProvider {
+    /// @notice Verify a ZK proof and return (success, nullifier).
+    /// @dev The nullifier is deterministic: same human + same scope
+    ///      always produces the same nullifier.
+    function verifyHumanProof(
+        bytes calldata proof,
+        bytes calldata data
+    ) external returns (bool verified, uint256 nullifier);
+
+    /// @notice Human-readable provider name (e.g. "Self Protocol").
+    function providerName() external view returns (string memory);
+
+    /// @notice Verification strength score (0-100).
+    function verificationStrength() external view returns (uint8);
+}
+```
+
+Self's `SelfHumanProofProvider` implements this, wrapping Self Protocol's [Identity Verification Hub V2](../self-pass/contracts/basic-integration.md).
+
+## Key concepts
+
+**Nullifier** — a scoped, opaque identifier unique per `(human, service)` pair, derived by the proof provider from the document. Two agents with the same nullifier belong to the same human. The nullifier is stored on-chain; the underlying document data is not. Nullifiers across different services are unlinkable.
+
+**Proof provider** — an approved contract that verifies proofs and reports a nullifier and strength. The registry keeps an allowlist (`isApprovedProvider`). Verifiers should require Self's provider unless they intentionally accept others.
+
+**maxAgentsPerHuman** — a registry-level cap on how many agents one human can hold at once (default 1). Prevents a single human from evading reputation decay by rotating agents.
+
+**proofExpiresAt** — a first-class expiry timestamp, `min(document expiry, registration time + maxProofAge)` (`maxProofAge` defaults to ~1 year). No oracle is needed: the expiry is set at registration and checked on-chain by `isProofFresh()`.
+
+`hasHumanProof()` returns true for any agent that ever proved humanity, including expired ones. `isProofFresh()` distinguishes "still valid" from "needs renewal," so callers can give different UX for each.
+
+## Verification strength
+
+`verificationStrength()` returns a 0-100 score describing how strongly the proof binds a human identity. The SDK maps the score to a label with `getProviderLabel(strength)`:
+
+| Score | SDK label |
+|-------|-----------|
+| ≥ 100 | `passport` |
+| ≥ 80 | `kyc` |
+| ≥ 60 | `govt_id` |
+| ≥ 40 | `liveness` |
+| < 40 | `unknown` |
+
+Self Protocol's provider currently reports **100** (`passport`), reflecting NFC passport / ID verification with biometric match. The `/api/reputation` and `/api/verify-status` endpoints return this score and label. This is distinct from the Reputation Registry's document-type weights (see below).
+
+## All three ERC-8004 registry types
+
+ERC-8004 defines three registry roles. Self Agent ID implements all three on-chain:
+
+- **Identity — `SelfAgentRegistry`.** Agent NFT minting, human proof storage, ZK-attested credentials, and metadata (A2A Agent Cards as `agentURI`).
+- **Reputation — `SelfReputationRegistry`.** Aggregated feedback with document-type weighted signals (E-Passport/EU ID Card 100, Aadhaar 80, KYC 50).
+- **Validation — `SelfValidationRegistry`.** On-demand validation requests and responses from third parties, with a configurable freshness threshold.
+
+See [Smart Contracts](smart-contracts.md) for the feedback, validation, and gating APIs.
+
+## Agent documents are also A2A Agent Cards
+
+The ERC-8004 registration document served at `agentURI` is designed to be optionally valid as an A2A Agent Card. A document that also contains `url`, `version`, `provider`, `capabilities`, and `securitySchemes` is simultaneously a valid A2A Agent Card, with no separate registration step. See [Agent Registration JSON & Agent Cards](agent-registration-json.md).
+
+## Sybil resistance properties
+
+1. Registration reverts when a human proof is required (default) and none is supplied.
+2. A nullifier can control at most `maxAgentsPerHuman` agents at once.
+3. Revoking an agent frees the nullifier slot, so the human can re-register.
+4. Expired proofs cause `isProofFresh()` to return false without any transaction.
+
+## Reference implementation
+
+The reference implementation uses the UUPS upgradeable proxy pattern, but implementers can choose any deployment strategy. The interfaces are proxy-agnostic.
+
+| Contract | Celo Mainnet (42220) |
+|----------|----------------------|
+| SelfAgentRegistry | [`0xaC3DF9ABf80d0F5c020C06B04Cced27763355944`](https://celoscan.io/address/0xaC3DF9ABf80d0F5c020C06B04Cced27763355944) |
+| SelfReputationRegistry | [`0x69Da18CF4Ac27121FD99cEB06e38c3DC78F363f4`](https://celoscan.io/address/0x69Da18CF4Ac27121FD99cEB06e38c3DC78F363f4) |
+| SelfValidationRegistry | [`0x71a025e0e338EAbcB45154F8b8CA50b41e7A0577`](https://celoscan.io/address/0x71a025e0e338EAbcB45154F8b8CA50b41e7A0577) |
+
+Celo Sepolia testnet addresses are listed in [Smart Contracts](smart-contracts.md#celo-sepolia-11142220). Source: [github.com/selfxyz/self-agent-id](https://github.com/selfxyz/self-agent-id).
+
+## EIP proposal status
+
+The Self Protocol team is preparing a PR to the ERC-8004 EIP proposing proof-of-human as an optional extension section, with the full interface specification, rationale, security considerations, and a link to this reference implementation. The draft targets ethereum-magicians discussion with deployed contract addresses before formal submission.
+
+## Next steps
+
+- [Smart Contracts](smart-contracts.md) — deployed addresses and the full on-chain API
+- [Agent Registration JSON & Agent Cards](agent-registration-json.md) — the identity document format
+- [Verification Patterns](verification-patterns.md) — how services and contracts consume these checks

--- a/agent-id/guides/agent-builder.md
+++ b/agent-id/guides/agent-builder.md
@@ -29,27 +29,9 @@ Six registration modes — choose based on your use case:
 | `privy` | Social login (Google, Twitter) | No |
 | `smartwallet` | Consumer-facing, passkey UX | No |
 
-### Via the dApp (simplest)
+### Via the SDK (simplest)
 
-1. Go to [selfagentid.xyz](https://selfagentid.xyz)
-2. Select your registration mode and network
-3. Scan your passport with the Self app
-4. Copy the agent private key from the export page
-
-#### What your user will see
-
-The dApp walks users through a guided wizard:
-
-1. **Role selection** — "I'm building an agent" or "I'm a human registering for my agent"
-2. **Key type** — ECDSA or Ed25519, with framework-specific hints (e.g. OpenClaw and Eliza use Ed25519)
-3. **Mode selection** — The wizard narrows the six modes to the ones that match the chosen key type, with a comparison table showing wallet requirements, NFT ownership, and revocation methods
-4. **Network** — Mainnet (real passport) or Testnet (mock documents)
-5. **Verification config** — Optional age threshold and OFAC screening
-6. **Key generation / import** — For ECDSA modes, a fresh keypair is generated in the browser. For Ed25519 modes, the user pastes the agent's existing public key
-7. **Passport scan** — A QR code or deep link opens the Self app for ZK proof-of-human verification
-8. **Confirmation** — On-chain registration completes and the agent key is available for export
-
-The entire flow takes under two minutes. No crypto knowledge is required for wallet-free, privy, or smartwallet modes.
+Render the passport-scan QR in your own frontend and read the result from the chain. No hosted service is involved. This is the recommended path. See [Register Without the Web App](../register-without-the-app.md) for the full runnable example (generate the agent key, sign the challenge, build the QR with `@selfxyz/qrcode`, mint on-chain).
 
 ### Via CLI
 
@@ -65,7 +47,7 @@ self-agent register init \
   --minimum-age 18 \
   --ofac
 
-# Open the browser handoff URL
+# Print the QR (fetched from the API) to scan with the Self app
 self-agent register open --session .self/session-*.json
 
 # Wait for verification to complete
@@ -75,12 +57,14 @@ self-agent register wait --session .self/session-*.json
 self-agent register export --session .self/session-*.json --unsafe --print-private-key
 ```
 
+The CLI talks to `https://agent-api.self.xyz` by default (override with `SELF_AGENT_API_BASE`).
+
 ### Via A2A Protocol (for agents)
 
 Agents can self-register by sending a JSON-RPC request to the A2A endpoint:
 
 ```bash
-curl -X POST https://selfagentid.xyz/api/a2a \
+curl -X POST https://agent-api.self.xyz/api/a2a \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -100,7 +84,7 @@ The endpoint returns a QR code and deep link. A human scans the QR with the Self
 ### Via REST API
 
 ```bash
-curl -X POST https://selfagentid.xyz/api/agent/register \
+curl -X POST https://agent-api.self.xyz/api/agent/register \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "linked",
@@ -114,11 +98,7 @@ Poll `/api/agent/register/status?token=<token>` until `stage: "completed"`.
 
 ### Via Smart Wallet (passkeys)
 
-1. Go to [selfagentid.xyz](https://selfagentid.xyz)
-2. Select "Smart Wallet" mode
-3. Create a passkey — this generates a ZeroDev Kernel smart account as your guardian
-4. Scan your passport with the Self app
-5. On mainnet, transactions are gasless via Pimlico paymaster
+Smart-wallet mode uses a passkey to create a ZeroDev Kernel smart account as the guardian, with gasless operations via the Pimlico paymaster on mainnet. Build the passkey step into your own frontend with `@zerodev/sdk` and `@zerodev/passkey-validator`; the agent keypair and challenge are generated the same way as `linked`. The gasless bundler and paymaster are proxied through `https://agent-api.self.xyz/api/aa/*`. See [Registration Modes](../registration-modes.md#smart-wallet).
 
 ## 3. Sign Outbound Requests
 

--- a/agent-id/guides/mcp-user.md
+++ b/agent-id/guides/mcp-user.md
@@ -118,6 +118,31 @@ Sign an HTTP POST request to https://api.example.com/data with body {"query": "t
 Make an authenticated request to https://api.example.com/protected.
 ```
 
+## Claude Code Plugin (guided workflows)
+
+For Claude Code specifically, the repo also ships a **plugin** that adds six skills. Each skill is a self-contained knowledge module (decision trees, code examples, reference docs) that loads automatically when your request matches, giving Claude full protocol context without manual setup.
+
+```bash
+# Clone the repo, then add the plugin from the local checkout
+git clone https://github.com/selfxyz/self-agent-id.git
+claude plugin add ./self-agent-id/plugin
+```
+
+| Skill | Covers |
+|-------|--------|
+| `self-agent-id-overview` | Architecture, contracts, trust model, ERC-8004, provider system |
+| `register-agent` | Registration in every mode (linked, wallet-free, ed25519, ed25519-linked, privy, smartwallet) |
+| `sign-requests` | ECDSA request signing, the 3-header auth system, signed-fetch patterns |
+| `verify-agents` | On-chain verification, `SelfAgentVerifier` middleware, reputation, freshness, sybil detection |
+| `query-credentials` | ZK-attested credentials, A2A agent cards, reputation scores |
+| `integrate-self-id` | End-to-end integration: agent-side, service-side, on-chain gating, MCP setup |
+
+The plugin and the MCP server are complementary: the plugin teaches Claude the protocol, while the MCP server gives it live tools to act on-chain.
+
+## Agents without MCP support
+
+Frameworks that cannot run an MCP server (LangChain, AutoGPT, custom runtimes) do not need it. The [REST API](../rest-api.md) and [A2A JSON-RPC endpoint](../rest-api.md#a2a-protocol-json-rpc) at `https://agent-api.self.xyz` expose registration, verification, lookup, and deregistration directly over HTTP, so any agent can drive the full lifecycle with plain requests.
+
 ## Resources
 
 The server exposes two MCP resources:

--- a/agent-id/guides/mcp-user.md
+++ b/agent-id/guides/mcp-user.md
@@ -60,7 +60,7 @@ Add to your MCP configuration file:
 | `SELF_AGENT_PRIVATE_KEY` | No | — | Agent private key (hex). Enables identity and auth tools. |
 | `SELF_NETWORK` | No | `mainnet` | `mainnet` or `testnet` |
 | `SELF_RPC_URL` | No | Network default | Custom RPC endpoint |
-| `SELF_API_URL` | No | `https://selfagentid.xyz` | Custom API base URL |
+| `SELF_AGENT_API_BASE` | No | `https://agent-api.self.xyz` | API base URL. Override to use your own deployment. |
 
 {% hint style="info" %}
 **Mainnet is the default.** Registration on mainnet requires a real passport via the Self app. Use `SELF_NETWORK=testnet` for development — testnet also requires the Self app, but you can generate mock documents within the app instead of using a real passport.

--- a/agent-id/guides/service-operator.md
+++ b/agent-id/guides/service-operator.md
@@ -215,7 +215,41 @@ The verifier checks that `getProofProvider(agentId)` matches Self Protocol's pro
 ```
 Per-agent sliding-window rate limits.
 
-## 9. Error Handling
+## 9. Request Body Fidelity (raw bytes)
+
+Signature verification is byte-sensitive: the signature covers a hash of the exact request body. Verify against the raw bytes your HTTP server received, not a re-serialized object.
+
+- Prefer raw-body capture (for example, a JSON parser `verify` hook that stashes `req.rawBody`).
+- Do not mutate, normalize, or re-stringify parsed JSON before verifying.
+- If you cannot access raw bytes, enforce a single canonical serialization end to end.
+
+```typescript
+import express from "express";
+
+const app = express();
+app.use(
+  express.json({
+    verify: (req: any, _res, buf) => {
+      req.rawBody = typeof buf === "string" ? buf : buf.toString("utf8");
+    },
+  }),
+);
+app.use("/api", verifier.auth());
+```
+
+## 10. Verification Drills
+
+Run these three drills against a registered agent to confirm an integration is wired correctly:
+
+| Drill | Action | Expected result |
+|-------|--------|-----------------|
+| **Tamper** | Sign body `A`, then send body `B` with the same signed headers | Invalid-signature rejection (`403`) |
+| **Expired** | Send a timestamp older than the configured `maxAge` (default 5 min) | Timestamp-freshness rejection (`403`) |
+| **Replay** | Submit an identical signed request twice | First accepted, second rejected (replay protection on) |
+
+A quick pre-deploy smoke check: one registered-agent success request plus at least two of the failure drills above, with the verifier health endpoint confirmed reachable.
+
+## 11. Error Handling
 
 The middleware returns standard HTTP errors:
 

--- a/agent-id/overview.md
+++ b/agent-id/overview.md
@@ -8,6 +8,10 @@ Self Agent ID is an on-chain identity registry that binds AI agent identities to
 
 The system implements the [ERC-8004 Proof-of-Human extension](https://eips.ethereum.org/EIPS/eip-8004) and provides SDK implementations in TypeScript, Python, and Rust with identical feature parity.
 
+{% hint style="info" %}
+There is no consumer website. You use Agent ID through the SDK, the on-chain registry, the REST/A2A API at `https://agent-api.self.xyz`, or the `self-agent` CLI. See [Register Without the Web App](register-without-the-app.md) to register, sign, and verify an agent.
+{% endhint %}
+
 ## Who This Is For
 
 | Audience | What You Do |
@@ -51,14 +55,16 @@ No personal data ever leaves the user's device. Only a ZK proof and nullifier ar
 Celo Sepolia chain ID is **11142220**, not 44787 (deprecated Alfajores).
 {% endhint %}
 
-## Live Deployment
+## Where It Lives
 
-- Web app: [https://selfagentid.xyz](https://selfagentid.xyz)
-- GitHub: [https://github.com/selfxyz/self-agent-id](https://github.com/selfxyz/self-agent-id)
+- API (REST + A2A): `https://agent-api.self.xyz`
+- Contracts: on Celo (addresses above)
+- SDKs: `@selfxyz/agent-sdk` (TypeScript), `selfxyz-agent-sdk` (Python), `self-agent-sdk` (Rust)
+- Source: [github.com/selfxyz/self-agent-id](https://github.com/selfxyz/self-agent-id)
 
 ## A2A Protocol
 
-Agents can interact programmatically via the A2A JSON-RPC endpoint at `/api/a2a`. This supports registration, verification, lookup, deregistration, and proof freshness checks — all through structured intents or natural language.
+Agents can interact programmatically via the A2A JSON-RPC endpoint at `https://agent-api.self.xyz/api/a2a`. This supports registration, verification, lookup, deregistration, and proof freshness checks — all through structured intents or natural language.
 
 Send `{ "intent": "help" }` to get a full list of capabilities and a decision guide for choosing the right registration mode.
 

--- a/agent-id/register-without-the-app.md
+++ b/agent-id/register-without-the-app.md
@@ -1,0 +1,148 @@
+---
+description: Register, sign, and verify an agent using only the SDK and the on-chain registry, with no website
+---
+
+# Register Without the Web App
+
+There is no consumer website for Self Agent ID. You render the passport-scan QR in your own app, the Self mobile app submits the proof on-chain, and the registry mints the agent. Signing and verification are on-chain too.
+
+This page shows the full loop with the SDK: register, sign, verify. It needs no hosted service at all. If you prefer, you can also register through the [CLI](cli.md) or the [REST/A2A API](rest-api.md) at `https://agent-api.self.xyz`, which return the QR for you to display.
+
+## What you need
+
+- `npm install @selfxyz/agent-sdk @selfxyz/qrcode ethers`
+- The Self mobile app on a phone. On testnet you can generate mock documents in the app, so no real passport is needed.
+- A Celo RPC. Public defaults: `https://forno.celo.org` (mainnet), `https://forno.celo-sepolia.celo-testnet.org` (testnet).
+
+| Network | Chain ID | Registry |
+|---------|----------|----------|
+| Celo Mainnet | `42220` | `0xaC3DF9ABf80d0F5c020C06B04Cced27763355944` |
+| Celo Sepolia (testnet) | `11142220` | `0x043DaCac8b0771DD5b444bCC88f2f8BBDBEdd379` |
+
+## 1. Register an agent
+
+Render the QR in your own frontend. The proof goes from the Self app to the on-chain Hub, which mints the agent NFT into the registry. No backend is involved.
+
+```tsx
+import { useEffect, useState } from 'react';
+import { SelfAppBuilder, SelfQRcodeWrapper } from '@selfxyz/qrcode';
+import { signRegistrationChallenge, buildAdvancedRegisterUserDataAscii } from '@selfxyz/agent-sdk';
+import { Wallet } from 'ethers';
+
+const REGISTRY = '0xaC3DF9ABf80d0F5c020C06B04Cced27763355944'; // Celo mainnet
+
+export function RegisterAgent({ humanAddress }: { humanAddress: string }) {
+  const [selfApp, setSelfApp] = useState<any>(null);
+  const [agentKey] = useState(() => Wallet.createRandom());
+
+  useEffect(() => {
+    (async () => {
+      // The agent key signs a challenge proving it controls the key
+      const sig = await signRegistrationChallenge(agentKey.privateKey, {
+        humanIdentifier: humanAddress,
+        chainId: 42220,
+        registryAddress: REGISTRY,
+        nonce: 0,
+      });
+
+      // Encode the registration payload (config index is derived from disclosures)
+      const disclosures = { minimumAge: 18, ofac: true };
+      const userDefinedData = buildAdvancedRegisterUserDataAscii({
+        agentAddress: agentKey.address,
+        signature: sig,
+        disclosures,
+      });
+
+      // Build the Self verification request; the registry is the on-chain endpoint
+      setSelfApp(
+        new SelfAppBuilder({
+          version: 2,
+          appName: 'My Agent',
+          scope: 'self-agent-id',
+          endpoint: REGISTRY,
+          endpointType: 'celo', // 'staging_celo' for testnet
+          userId: humanAddress,
+          userIdType: 'hex',
+          userDefinedData,
+          disclosures,
+        }).build(),
+      );
+    })();
+  }, [humanAddress]);
+
+  return selfApp ? (
+    <SelfQRcodeWrapper
+      selfApp={selfApp}
+      onSuccess={() => {
+        // Minted. Save agentKey.privateKey securely — it is the agent's key.
+      }}
+      onError={() => console.error('verification failed')}
+    />
+  ) : (
+    <p>Loading…</p>
+  );
+}
+```
+
+The user scans the QR with the Self app. On `onSuccess` the agent NFT is minted. **Save the agent private key.** This example uses `linked` mode; for other modes (wallet-free, Ed25519, etc.) see [Registration Modes](registration-modes.md).
+
+{% hint style="info" %}
+For a headless flow, use `getUniversalLink(selfApp)` from `@selfxyz/qrcode` to produce the deep link instead of the React component, and read the new agent from the registry with `getAgentId` / `isVerifiedAgent`.
+{% endhint %}
+
+## 2. Publish the agent's identity document (optional but recommended)
+
+Agents minted this way start with a blank `agentURI`. Publish a JSON document so services and indexers can discover the agent, then point the agent at it.
+
+```typescript
+import { generateRegistrationJSON } from '@selfxyz/agent-sdk';
+
+const doc = generateRegistrationJSON({
+  name: 'My Agent',
+  description: 'A human-backed AI agent',
+  image: 'https://my-agent.example.com/avatar.png',
+  services: [{ name: 'A2A', endpoint: 'https://my-agent.example.com/a2a', version: '1.0' }],
+});
+// Host doc over HTTPS, then call registry.setAgentURI(agentId, url)
+```
+
+## 3. Sign requests as the agent
+
+```typescript
+import { SelfAgent } from '@selfxyz/agent-sdk';
+
+const agent = new SelfAgent({
+  privateKey: process.env.AGENT_PRIVATE_KEY!,
+  registryAddress: '0xaC3DF9ABf80d0F5c020C06B04Cced27763355944',
+  rpcUrl: 'https://forno.celo.org',
+});
+
+const res = await agent.fetch('https://some-service.example.com/api/protected', {
+  method: 'POST',
+  body: JSON.stringify({ hello: 'world' }),
+});
+```
+
+## 4. Verify the agent in a service
+
+The verifier recovers the signer and checks the registry on-chain. No API, no shared secret.
+
+```typescript
+import { SelfAgentVerifier } from '@selfxyz/agent-sdk';
+
+const verifier = new SelfAgentVerifier({
+  registryAddress: '0xaC3DF9ABf80d0F5c020C06B04Cced27763355944',
+  rpcUrl: 'https://forno.celo.org',
+});
+
+app.use('/api', verifier.auth()); // rejects requests from unverified agents
+```
+
+That is the whole product: register on-chain, sign, verify on-chain. Nothing here depends on a hosted Self website.
+
+## Next steps
+
+- [Registration Modes](registration-modes.md) — pick the key type and ownership model
+- [SDK Integration](sdk-integration.md) — signing and verification in TypeScript, Python, and Rust
+- [Verification Patterns](verification-patterns.md) — `sameHuman`, proof freshness, policy controls
+- [Smart Contracts](smart-contracts.md) — gate a contract on verified agents

--- a/agent-id/rest-api.md
+++ b/agent-id/rest-api.md
@@ -33,8 +33,8 @@ Returns agent registration details, verification status, and credentials.
   "agentAddress": "0x83fa4380903fecb801F4e123835664973001ff00",
   "isVerified": true,
   "proofProvider": "0x5E61c3051Bf4115F90AacEAE6212bc419f8aBB6c",
-  "verificationStrength": 2,
-  "strengthLabel": "Standard",
+  "verificationStrength": 100,
+  "strengthLabel": "passport",
   "credentials": {
     "nationality": "GBR",
     "olderThan": 18,
@@ -69,20 +69,25 @@ Returns all agent IDs registered by a specific human wallet address.
 GET /api/agent/verify/{chainId}/{agentId}
 ```
 
-Checks whether an agent has valid proof-of-human verification, the proof provider address, verification strength, and Sybil metrics.
+Checks whether an agent has valid proof-of-human verification, the proof provider address, verification strength, and Sybil metrics. `isSelfProvider` is `true` when the proof was issued by Self Protocol's provider. `agentCountForHuman` is how many agents share this human's nullifier.
 
 **Example response:**
 
 ```json
 {
   "agentId": 5,
+  "chainId": 11142220,
   "isVerified": true,
   "proofProvider": "0x5E61c3051Bf4115F90AacEAE6212bc419f8aBB6c",
-  "strengthLabel": "Standard",
-  "humanAgentCount": 1,
-  "maxAgentsPerHuman": 1
+  "isSelfProvider": true,
+  "verificationStrength": 100,
+  "strengthLabel": "passport",
+  "humanNullifier": "12345678901234567890",
+  "agentCountForHuman": 1
 }
 ```
+
+When an agent has no proof, the response is `{ "agentId", "chainId", "isVerified": false, "proofProvider": "0x000…000", "isSelfProvider": false, "verificationStrength": 0, "strengthLabel": "None", "humanNullifier": "0", "agentCountForHuman": 0 }`.
 
 ### Get Agent Card
 
@@ -104,12 +109,14 @@ Returns the agent's verification strength score from the proof provider.
 
 ```json
 {
-  "score": 2,
+  "score": 100,
   "hasProof": true,
   "providerName": "Self Protocol",
-  "proofType": "Standard"
+  "proofType": "passport"
 }
 ```
+
+The `score` is the provider's `verificationStrength()` (0-100). `proofType` is the SDK label for that score: `passport` (≥100), `kyc` (≥80), `govt_id` (≥60), `liveness` (≥40), else `unknown`. Self Protocol's provider currently returns `100` / `passport`.
 
 ### Get Verification Status
 
@@ -124,11 +131,13 @@ Returns real-time proof status and freshness.
 ```json
 {
   "verified": true,
-  "proofType": "Standard",
+  "proofType": "passport",
   "registeredAtBlock": "12345678",
   "providerAddress": "0x5E61c3051Bf4115F90AacEAE6212bc419f8aBB6c"
 }
 ```
+
+When the agent has no proof, the response is simply `{ "verified": false }`.
 
 ### A2A Discovery
 

--- a/agent-id/rest-api.md
+++ b/agent-id/rest-api.md
@@ -4,11 +4,13 @@ description: REST API endpoints for agent registration, queries, and discovery
 
 # REST API
 
-Self Agent ID exposes REST endpoints for registration workflows, agent queries, and A2A discovery. All endpoints are served from the web app deployment.
+Self Agent ID exposes REST endpoints for registration workflows, agent queries, and A2A discovery. The base URL is `https://agent-api.self.xyz`. There is no consumer web app, but the full API stays available at this host. Prefix the paths below with the base URL.
 
 The full OpenAPI 3.1 spec is available at [`openapi.yaml`](https://github.com/selfxyz/self-agent-id/blob/main/openapi.yaml) in the main repository — import it into Postman or use it to generate clients.
 
-For interactive documentation, visit [selfagentid.xyz/api-docs](https://selfagentid.xyz/api-docs).
+{% hint style="info" %}
+Most query endpoints are thin wrappers over registry contract reads, so you can also reproduce them directly with the SDK or a plain RPC call. See [Smart Contracts](smart-contracts.md). To register without calling the API at all, render the QR in your own frontend with the SDK — see [Register Without the Web App](register-without-the-app.md).
+{% endhint %}
 
 ## Public Query Endpoints
 
@@ -178,7 +180,7 @@ Returns the service discovery document with API base URL, supported networks, re
 {
   "name": "Self Agent ID",
   "version": "1.0",
-  "apiBase": "https://selfagentid.xyz/api/agent",
+  "apiBase": "https://agent-api.self.xyz/api/agent",
   "networks": ["mainnet", "testnet"],
   "registrationModes": ["linked", "wallet-free", "ed25519", "ed25519-linked", "privy", "smartwallet"],
   "capabilities": ["register", "deregister", "verify", "credentials", "agent-card", "a2a"],

--- a/agent-id/sdk-integration.md
+++ b/agent-id/sdk-integration.md
@@ -88,7 +88,7 @@ import { SelfAgentVerifier } from "@selfxyz/agent-sdk";
 const verifier = SelfAgentVerifier.create()
   .requireAge(18)
   .requireOFAC()
-  .maxAgentsPerHuman(1)
+  .sybilLimit(1)
   .build();
 
 // Express middleware
@@ -103,7 +103,7 @@ from self_agent_sdk import SelfAgentVerifier
 verifier = (SelfAgentVerifier.create()
     .require_age(18)
     .require_ofac()
-    .max_agents_per_human(1)
+    .sybil_limit(1)
     .build())
 
 # Flask middleware
@@ -122,7 +122,7 @@ use self_agent_sdk::SelfAgentVerifier;
 let verifier = SelfAgentVerifier::builder()
     .require_age(18)
     .require_ofac()
-    .max_agents_per_human(1)
+    .sybil_limit(1)
     .build()?;
 
 // Axum middleware (requires `axum` feature)
@@ -157,7 +157,7 @@ if (result.valid) {
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `requireSelfProvider` | `true` | Only accept proofs from Self Protocol's provider |
-| `maxAgentsPerHuman` | `1` | One agent per human (sybil resistance) |
+| `sybilLimit` | `1` | One agent per human (sybil resistance); `0` disables the cap |
 | Replay protection | Enabled | Signature nonce + timestamp freshness |
 | Timestamp window | 300 seconds | Reject requests older than 5 minutes |
 

--- a/agent-id/verification-patterns.md
+++ b/agent-id/verification-patterns.md
@@ -83,7 +83,7 @@ Services can enforce their own sybil policies using three approaches:
 
 ```typescript
 const verifier = SelfAgentVerifier.create()
-  .maxAgentsPerHuman(1)
+  .sybilLimit(1)
   .build();
 ```
 
@@ -91,7 +91,7 @@ const verifier = SelfAgentVerifier.create()
 
 ```typescript
 const verifier = SelfAgentVerifier.create()
-  .maxAgentsPerHuman(5)
+  .sybilLimit(5)
   .build();
 ```
 
@@ -100,7 +100,7 @@ const verifier = SelfAgentVerifier.create()
 ```typescript
 // Allow unlimited, but check relationships
 const verifier = SelfAgentVerifier.create()
-  .maxAgentsPerHuman(0) // unlimited
+  .sybilLimit(0) // unlimited
   .build();
 
 // Then use sameHuman() for analytics


### PR DESCRIPTION
## What

Updates the Self Agent ID docs for the API migration: the hosted consumer
web app is being retired and the API moves to a dedicated host
(`agent-api.self.xyz`). All features are retained — nothing is dropped.

## Changes

- **New page — Register Without the Web App**: SDK-first registration loop
  (render the QR client-side with `@selfxyz/qrcode`, mint on-chain, sign,
  verify). Needs no hosted service. Added to the Agent ID nav.
- **Rehosted all API references** to `https://agent-api.self.xyz` (was
  `selfagentid.xyz`): REST API, A2A endpoint, CLI, Celo Agent Visa, AA proxy.
- **overview.md**: "Where It Lives" now lists the API host; consumer-website
  framing updated.
- **rest-api.md**: base URL set to the new host; removed the dead
  `api-docs` link; `apiBase` example updated.
- **cli.md**: notes the CLI uses `agent-api.self.xyz` (override via
  `SELF_AGENT_API_BASE`) and fetches the QR from `/api/qr/{sessionToken}`.
- **agent-builder.md**: replaced the retired dApp wizard with the SDK path;
  updated A2A/REST examples and the smart-wallet section.
- **mcp-user.md**: `SELF_AGENT_API_BASE` default updated.

## Not changing

On-chain registration (Hub V2 mint) and verification are unaffected — they
never depended on the hosted app. No features removed.